### PR TITLE
fix(fish): eagerly load shell magic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -315,7 +315,10 @@ check_shell_magic() {
 
 		if gum confirm 'magic?' --affirmative="add one-liner" --negative="skip"
 		then
-			"$SHELL" -c "function add_tea_environment --on-variable PWD; source <(teal -Eds|psub); end; funcsave add_tea_environment >/dev/null"
+			cat <<-EOSH >> "${XDG_CONFIG_HOME:-~/.config}/fish/config.fish"
+
+				function add_tea_environment --on-variable PWD; tea -Eds | source; end  #tea
+				EOSH
 		fi
 	else
 		gum format -- <<-EOMD


### PR DESCRIPTION
The current fish hook is lazily loaded, so it won't take effect in a given shell unless a user first manually calls `add_tea_environment`. From the [docs](https://fishshell.com/docs/current/language.html?highlight=Please+note+that#event-handlers):

> Please note that event handlers only become active when a function is loaded, which means you need to otherwise source or execute a function instead of relying on autoloading. One approach is to put it into your configuration file.

This just moves it to the main [configuration file](https://fishshell.com/docs/current/language.html#configuration-files), typically at `~/.config/fish/config.fish`
