### PR TITLE
Explicit deps are not required for GHA action.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - install.sh
       - .github/workflows/ci.yml
       - action.js
+      - README.md
   workflow_call:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -70,11 +70,4 @@ See our CI scripts for details.
 node --check ./action.js
 ```
 
-## Dependencies
-
-|   Project   | Version |
-|-------------|---------|
-| nodejs.org  | ^16     |
-
-
 [`action.yml`]: ./action.yml


### PR DESCRIPTION
Demonstrating how when there is no `.git` folder we fail to get the node dep from the `action.yml`.