### PR TITLE
tea magic one-liner for bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -320,6 +320,22 @@ check_shell_magic() {
 				function add_tea_environment --on-variable PWD; tea -Eds | source; end  #tea
 				EOSH
 		fi
+	elif test "$sh" = "bash"; then
+		gum format -- <<-EOMD
+			# want magic?
+			tea’s shell magic works via a simple function in bash \\
+			it’s not required, **but we do recommend it**.
+
+			> docs https://github.com/teaxyz/cli#usage-as-an-environment-manager
+			EOMD
+
+		if gum confirm 'magic?' --affirmative="add one-liner" --negative="skip"
+		then
+			cat <<-EOSH >> ~/.bashrc
+
+				cd() { builtin cd "\$@" || return; [ "\$OLDPWD" = "\$PWD" ] || source <(tea -Eds); }
+				EOSH
+		fi
 	else
 		gum format -- <<-EOMD
 			# we need your help 🙏


### PR DESCRIPTION
I took a stab at implementing the `magic` bash one-liner in the install script. 

I noticed that bash was recently added to tea: https://github.com/teaxyz/cli/pull/173 

I have not been able to produce the behavior where tea automatically discovers requirements when I `cd` into a directory. I used the tea cli (https://github.com/teaxyz/cli) repository for testing. I confirmed that the virtualenv is created and any dependencies previously installed are available in the path. 

I'm digging a little more to see how the autodiscover could be working in the other shells using the same `tea -Eds` command.

Feedback appreciated. <3 