### PR TITLE
defend against gitea also using `tea`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,4 +172,4 @@ jobs:
           tea --help
       - uses: actions/checkout@v3
       - run: ./install.sh
-      - run: ~/.tea/tea.xyz/v0/bin/tea --prefix
+      - run: test $(~/.tea/tea.xyz/v0/bin/tea --prefix) = $HOME/.tea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,23 @@ jobs:
         - run: sudo chmod go-w /usr/local/bin
         # ^^ we run as `runner` but this dir has 999 perms
         - run: ./install.sh
+
+  installs-if-gitea-found:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install gitea
+        run: |
+          sudo curl -sL -o /etc/apt/trusted.gpg.d/morph027-gitea.asc https://packaging.gitlab.io/gitea/gpg.key
+          echo "deb https://packaging.gitlab.io/gitea gitea main" | sudo tee /etc/apt/sources.list.d/morph027-gitea.list
+          sudo apt-get update
+          sudo apt-get install gitea morph027-keyring
+          sudo mv /usr/bin/gitea /usr/bin/tea
+        # ^^ lol actually pretty much the only time `gitea` installs as `tea` is via `brew`
+      - name: test gitea is there
+        run: |
+          dpkg -L gitea
+          which tea
+          tea --help
+      - uses: actions/checkout@v3
+      - run: ./install.sh
+      - run: ~/.tea/tea.xyz/v0/bin/tea --prefix

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ prepare() {
 		echo "tea: error: sorry. pls install tar :(" >&2
 	fi
 
-	if test -n "$VERBOSE"; then
+	if test -n "$VERBOSE" -o -n "$GITHUB_ACTIONS" -a -n "$RUNNER_DEBUG"; then
 		set -x
 	fi
 
@@ -95,8 +95,14 @@ prepare() {
 	if test -z "$TEA_PREFIX"; then
 		# use existing installation if found
 		if which tea >/dev/null 2>&1; then
+			set +e
 			TEA_PREFIX="$(tea --prefix --silent)"
-			ALREADY_INSTALLED=1
+			set -e
+			if test $? -eq 0 -a -n "$TEA_PREFIX"; then
+				ALREADY_INSTALLED=1
+			else
+				unset TEA_PREFIX
+			fi
 		fi
 
 		# we check again: in case the above failed for some reason
@@ -235,7 +241,6 @@ fix_links() {
 	link "$(echo "$v" | cut -d. -f1)"
 	link "$(echo "$v" | cut -d. -f1-2)"
 	cd "$OLDWD"
-
 }
 
 install() {
@@ -279,8 +284,8 @@ check_path() {
 		echo  #spacer
 
 		if test -w /usr/local/bin -o -w /usr/local -a ! -d /usr/local/bin
-    then
-      mkdir -p /usr/local/bin
+		then
+			mkdir -p /usr/local/bin
 			ln -sf "$tea" /usr/local/bin/tea
 		elif which sudo >/dev/null 2>&1
 		then

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ prepare() {
 			else
 				unset TEA_PREFIX
 			fi
-      set -e
+			set -e
 		fi
 
 		# we check again: in case the above failed for some reason

--- a/install.sh
+++ b/install.sh
@@ -97,12 +97,12 @@ prepare() {
 		if which tea >/dev/null 2>&1; then
 			set +e
 			TEA_PREFIX="$(tea --prefix --silent)"
-			set -e
 			if test $? -eq 0 -a -n "$TEA_PREFIX"; then
 				ALREADY_INSTALLED=1
 			else
 				unset TEA_PREFIX
 			fi
+      set -e
 		fi
 
 		# we check again: in case the above failed for some reason


### PR DESCRIPTION
gitea also provides `tea`. Somehow during my due diligence I didn’t discover this. Like maybe they turned up before us but after I looked around?

Dunno, too late though, we have to defend against it. This at least recognizes that `tea` is not ours.

TODO: offer to symlink to `teaxyz` instead of `tea` :/