### PR TITLE
Fix installing Fish shell magic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -359,7 +359,7 @@ check_shell_magic() {
 
 		if gum_func confirm 'magic?' --affirmative="add one-liner" --negative="skip"
 		then
-			cat <<-EOSH >> "${XDG_CONFIG_HOME:-~/.config}/fish/config.fish"
+			cat <<-EOSH >> "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
 
 				function add_tea_environment --on-variable PWD; tea -Eds | source; end  #tea
 				EOSH


### PR DESCRIPTION
The current version gives:

```
sh: line 362: ~/.config/fish/config.fish: No such file or directory
```

This is because the `~` is inside of quotes, so isn't expanded.