### PR TITLE
use $GITHUB_WORKSPACE/opt as a preferred fallback to $HOME/opt

### DIFF
--- a/action.js
+++ b/action.js
@@ -7,7 +7,9 @@ const os = require("os")
 async function go() {
   process.stderr.write("determining latest tea version…\n")
 
-  const PREFIX = process.env['INPUT_PREFIX'] || `${os.homedir()}/opt`
+  const HOMEDIR = process.env['GITHUB_WORKSPACE'] || os.homedir()
+
+  const PREFIX = process.env['INPUT_PREFIX'] || `${HOMEDIR}/opt`
   const TEA_DIR = (() => {
     let TEA_DIR = process.env['INPUT_SRCROOT']
     if (!TEA_DIR) return


### PR DESCRIPTION
one our runners, we blow away $GITHUB_WORKSPACE per design, but removing $HOME unilaterally would definitely break stuff. Mitigated via https://github.com/teaxyz/infuser/commit/2da33b314bbf7539211e5ae9a617a2cf4ebb94df