### PR TITLE
Fix installation for bash 3.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -420,6 +420,7 @@ check_shell_magic() {
 	bash)
 		__TEA_SH_FILE="$HOME/.bashrc"
 		__TEA_BTN_TXT="add one-liner to your \`~/.bashrc\`?"
+		__TEA_ONE_LINER="test -d \"$TEA_DESTDIR_WRITABLE\" && source /dev/stdin <<<\"\$(\"$TEA_DESTDIR_WRITABLE/tea.xyz/v*/bin/tea\" --magic=$SHELL --silent)\""
 		;;
 	elvish)
 		__TEA_SH_FILE="$HOME/.config/elvish/rc.elv"


### PR DESCRIPTION
Installation currently fails on bash 3.2 (the default version of bash that ships with macOS). 
This is due to a [bug in bash 3.2 related to sourcing from a process substitution.](https://lists.gnu.org/archive/html/bug-bash/2006-01/msg00018.html)

This is a known workaround that will work for bash 3.x and newer versions.