### PR TITLE
switching to echo to /bin/echo for pantry install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -498,7 +498,7 @@ elif command -v git >/dev/null 2>&1; then
 	title="syncing"
 fi
 
-gum_func spin --title "$title pantry" -- "$TEA_EXENAME" --sync --cd / echo
+gum_func spin --title "$title pantry" -- "$TEA_EXENAME" --sync --cd / /bin/echo
 
 case $MODE in
 install)


### PR DESCRIPTION
While installing `tea` on `linux/amd64` hosts, the pantry sync returns code 139, failing to complete the installation. While no such errors are generated on `linux/arm64` systems.
The pantry sync is performed by passing `--sync --cd / echo` to the tea CLI. The `echo` is a shell builtin, while `/bin/echo` is a binary. Let's use the proper binary.

* replacing `echo` with `/bin/echo` in `install.sh` pantry sync command

Closes #148